### PR TITLE
docs(typo): Fix typo in intel-gpu-top plugin description

### DIFF
--- a/intel-gpu-top.plg
+++ b/intel-gpu-top.plg
@@ -90,7 +90,7 @@ rm -f $(ls /boot/config/plugins/&name;/intel.gpu.top*.txz 2>/dev/null|grep -v '&
 <INLINE>
 **Intel GPU TOP**
 
-This plugin adds the tool 'intel_gpu_top' to your unRAID server and also enables your Intel iGPU from the installation of this plugin on, so no editis to the 'go' file or creation of other files are necessary.
+This plugin adds the tool 'intel_gpu_top' to your unRAID server and also enables your Intel iGPU from the installation of this plugin on, so no edits to the 'go' file or creation of other files are necessary.
 To see the usage of your iGPU open up the unRAID Terminal and type in 'intel_gpu_top' (without quotes).
 This plugin satisfies installation prerequisites of the GPU Statistics plugin from Community Apps. With both plugins installed you can display Intel GPU utilization on the unRAID Dashboard.
 </INLINE>


### PR DESCRIPTION
Corrected a typo in the plugin description regarding 'edits'.